### PR TITLE
Impl push/pop feature & fix bugs

### DIFF
--- a/lib/pages/product.dart
+++ b/lib/pages/product.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 
 class ProductPage extends StatelessWidget {
-
   // passing data from external
   final String title;
   final String imageUrl;
@@ -11,25 +11,34 @@ class ProductPage extends StatelessWidget {
   Widget build(BuildContext context) {
     // TODO: implement build
     // Replace the homepage, so return a new scaffold
-    return Scaffold(
-        appBar: AppBar(
-          title: Text('Product detail'),
-        ),
-        body: Column(
-          // mainAxisAlignment: MainAxisAlignment.center, // from top to bottom
-          crossAxisAlignment: CrossAxisAlignment.center, // from left to right
-          children: <Widget>[
-            Image.asset(imageUrl),
-            Container(padding: EdgeInsets.all(10.0), child: Text(title)),
-            Container(
-                padding: EdgeInsets.all(10.0),
-                child: RaisedButton(
-                  color: Theme.of(context).accentColor,
-                  child: Text('DELETE'),
-                  onPressed: () =>
-                      Navigator.pop(context, true), // return to previous page, true -> Delete the page
-                )),
-          ],
-        ));
+    // However, when clicking the default return button which locates on upper left corner, the returned value would be null
+    // To solve this issue, wrap the scafold in a WillPopScope() widget.
+    return WillPopScope(
+        child: Scaffold(
+            appBar: AppBar(
+              title: Text('Product detail'),
+            ),
+            body: Column(
+              // mainAxisAlignment: MainAxisAlignment.center, // from top to bottom
+              crossAxisAlignment:
+                  CrossAxisAlignment.center, // from left to right
+              children: <Widget>[
+                Image.asset(imageUrl),
+                Container(padding: EdgeInsets.all(10.0), child: Text(title)),
+                Container(
+                    padding: EdgeInsets.all(10.0),
+                    child: RaisedButton(
+                      color: Theme.of(context).accentColor,
+                      child: Text('DELETE'),
+                      onPressed: () => Navigator.pop(context,
+                          true), // return to previous page, true -> Delete the page
+                    )),
+              ],
+            )),
+        // The onWillPop argument receives a function that concerns about left upper corner return button.
+        onWillPop: () {
+          Navigator.pop(context, false);
+          return Future.value(false); // -> you're allowed to leave, but true will trigger another pop action
+        });
   }
 }


### PR DESCRIPTION
The previous version would cause problems if I clicked the default return button, which locates on the left upper corner of the app. This is caused by unhandled exception in this code slice:
```dart
onPressed: () => Navigator.pop(context,
                          true), // return to previous page, true -> Delete the page
                    )),
```
If the delete button is pressed, the pop method is called and pass a true value into ***then*** function in Navigator.push()
```dart
              FlatButton(
                child: Text('Details'),
                onPressed: () => Navigator.push<bool>(
                        context,
                        MaterialPageRoute(
                          builder: (BuildContext context) => ProductPage(
                              products[index]['title'],
                              products[index]
                                  ['image']), // passing a data into ProductPage
                        )).then((bool value) {
                      // then method: a function which is eventually executed when event occurs(navigation finished)
                      // based on the value that passed back
                      if (value) {
                        deleteProduct(index);
                      }
                    }),
              )
```
However, if the button is not pressed the value would be null. To solve this issue, the product page is wrapped into ***WillPopScope*** widget. This widget has ***onWillPop()*** parameter which takes a function as argument. In this case, the function is Navigator.pop() with no doubt, and pass a false value back. Note that this func returned a **Future.value(false)**, which controls the behavior of default return button. 